### PR TITLE
Bug1185: Using i18n for event dates

### DIFF
--- a/app/helpers/mweb_events/events_helper.rb
+++ b/app/helpers/mweb_events/events_helper.rb
@@ -3,14 +3,21 @@ module MwebEvents
 
     def event_logo(event, options={})
       options[:class] = "#{options[:class]} mweb_events-event-logo"
-
+      format = I18n.t('_other.datetime.simple_format').split(/-| /)
       day = sanitize(event.start_on.strftime("%d"))
       month = localize(event.start_on, :format => "%b")
       hour = event.get_formatted_hour
       year = sanitize(event.start_on.strftime("%Y"))
 
+      day_txt =
+        if format.first == "dd"
+          day + ' ' + month
+        else
+          month + ' ' + day
+        end
+
       hour_tag = content_tag(:div, hour, { :class => 'mweb_events-event-logo-hour' })
-      day_tag = content_tag(:div, day + ' ' + month, { :class => 'mweb_events-event-logo-day' })
+      day_tag = content_tag(:div, day_txt , { :class => 'mweb_events-event-logo-day' })
       year_tag = content_tag(:div, year, { :class => 'mweb_events-event-logo-year' })
 
       content_tag(:div, day_tag + hour_tag + year_tag, options)

--- a/app/models/mweb_events/event.rb
+++ b/app/models/mweb_events/event.rb
@@ -185,17 +185,18 @@ module MwebEvents
 
     # Returns a string with the starting date of an event in the correct format
     def get_formatted_date(date=nil, with_tz=true)
+      format = I18n.t('_other.datetime.complete_rails_format')
       if date.nil?
         if with_tz
-          I18n::localize(start_on, :format => "%A, %d %b %Y, %H:%M (#{get_formatted_timezone})")
+          I18n::localize(start_on, :format => "#{format} (#{get_formatted_timezone})")
         else
-          I18n::localize(start_on, :format => "%A, %d %b %Y, %H:%M")
+          I18n::localize(start_on, :format => "#{format}")
         end
       else
         if with_tz
-          I18n::localize(date, :format => "%A, %d %b %Y, %H:%M (#{get_formatted_timezone(date)})")
+          I18n::localize(date, :format => "#{format} (#{get_formatted_timezone(date)})")
         else
-          I18n::localize(date, :format => "%A, %d %b %Y, %H:%M")
+          I18n::localize(date, :format => "#{format}")
         end
       end
     end

--- a/config/locales/mweb_events.en.yml
+++ b/config/locales/mweb_events.en.yml
@@ -38,6 +38,9 @@ en:
     update: Update
     more: Read More
     close: Close
+    datetime:
+      complete_rails_format: "%A, %b %d %Y, %H:%M"
+      simple_format: "MM-dd-yyyy hh:mm"
 
   mweb_events:
     participant:

--- a/config/locales/mweb_events.pt.yml
+++ b/config/locales/mweb_events.pt.yml
@@ -39,6 +39,9 @@ pt:
     update: Atualizar
     more: Ler Mais
     close: Fechar
+    datetime:
+      complete_rails_format: "%A, %d %b %Y, %H:%M"
+      simple_format: "dd-MM-yyyy hh:mm"
 
   mweb_events:
     participant:


### PR DESCRIPTION
Places where it's used:
- in the event logo generation (basic implementation)
- in the get_formatted_date method of the Event model

refs #1185
